### PR TITLE
Fixing the Overlapping of your modal images

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,36 +78,35 @@
 
 
               <!-- Images used to open the lightbox -->
-  <div class="row gallery">
-    <div class="column classy">
-      <img src="images/awards-purple.png" onclick="openModal();currentSlide(1)" class="hover-shadow">
-    </div>
-    <div class="column classy">
-      <img src="images/poetry-purple.png" onclick="openModal();currentSlide(2)" class="hover-shadow">
-    </div>
-    <div class="column classy">
-      <img src="images/stories-purple.png" onclick="openModal();currentSlide(3)" class="hover-shadow">
-    </div>
+   <div class="row">
+     <div class="col-xs-12 col-sm-4 classy">
+       <img src="images/awards-purple.png" onclick="openModal();currentSlide(1)" class="hover-shadow img-responsive">
+     </div>
+     <div class="col-xs-12 col-sm-4 classy">
+       <img src="images/poetry-purple.png" onclick="openModal();currentSlide(2)" class="hover-shadow img-responsive">
+     </div>
+     <div class="col-xs-12 col-sm-4 classy">
+       <img src="images/stories-purple.png" onclick="openModal();currentSlide(3)" class="hover-shadow img-responsive">
+     </div>
 
-  </div>
+   </div>
 
-    <br>
-    <br>
+     <br>
+     <br>
 
-<div class="row gallery">
-    <div class="column classy">
-      <img src="images/conferences-purple.png" onclick="openModal();currentSlide(4)" class="hover-shadow">
-    </div>
-    <div class="column classy">
-      <img src="images/research-purple.png" onclick="openModal();currentSlide(5)" class="hover-shadow">
-    </div>
-    <div class="column classy">
-      <img src="images/events-purple.png" onclick="openModal();currentSlide(6)" class="hover-shadow">
-    </div>
+ <div class="row">
+     <div class="col-xs-12 col-sm-4 classy">
+       <img src="images/conferences-purple.png" onclick="openModal();currentSlide(4)" class="hover-shadow img-responsive">
+     </div>
+     <div class="col-xs-12 col-sm-4 classy">
+       <img src="images/research-purple.png" onclick="openModal();currentSlide(5)" class="hover-shadow img-responsive">
+     </div>
+     <div class="col-xs-12 col-sm-4 classy">
+       <img src="images/events-purple.png" onclick="openModal();currentSlide(6)" class="hover-shadow img-responsive">
+     </div>
 
-    </div>
-  </div>
-
+     </div>
+   </div>
   <!-- The Modal/Lightbox -->
   <div id="myModal" class="modal">
     <span class="close cursor" onclick="closeModal()">&times;</span>

--- a/main.css
+++ b/main.css
@@ -247,6 +247,10 @@ img.demo {
   opacity: 0.6;
 }
 
+.img-responsive{
+  display: inline;
+}
+
 .active,
 .demo:hover {
   opacity: 1;

--- a/main.css
+++ b/main.css
@@ -260,17 +260,10 @@ img.hover-shadow {
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19)
 }
 
-/*.gallery {
-  margin: auto;
-  padding: 20px;
-
-}
-*/
 
 .classy {
   padding: 10px;
   margin-top: 30px;
-  margin-left: 80px;
 }
 
 .icons {


### PR DESCRIPTION
Hey, I saw your forum post about your modal images overlapping when you make the screen-size smaller. I created a version that makes the images responsive so that they don't overlap anymore and when in mobile they stack under one another. Hopefully this helps! :) 

P.S. Here is the link to your original posting in the forum: https://github.community/t5/Pages/Making-Modals-Responsive/m-p/5683 
